### PR TITLE
productionコンテナの定期deploy:cleanup実施追加

### DIFF
--- a/scripts/deploy.coffee
+++ b/scripts/deploy.coffee
@@ -1,3 +1,5 @@
+cronJob = require('cron').CronJob
+
 {spawn, exec}  = require 'child_process'
 module.exports = (robot) ->
   robot.respond /deploy (.*)$/i , (msg) ->
@@ -22,3 +24,14 @@ module.exports = (robot) ->
       else
         msg.send "--- Deploy finished."
 
+  new cronJob('20 15 * * *', () ->
+    projects = ["remp", "stbd", "casto"]
+
+    for pj,i in projects
+      exec "cd tmp/#{pj} && bundle exec mina deploy:cleanup", (err, stdout, stderr) ->
+        if err
+          robot.send {room:'remp_team'}, "#{pj} container deploy:cleanup failed....."
+        else
+          robot.send {room:'remp_team'}, "#{pj} container deploy:cleanup success....."
+
+  ).start()


### PR DESCRIPTION
### 解決したいこと
- 定期的に `mina deploy:cleanup` を行わせます。
- 対象のプロジェクトはREMP, STORYBOARDS, Casto です。
