### PR TITLE
deploy:cleanup がプロジェクト毎に行えてなかった不具合修正

### DIFF
--- a/scripts/deploy.coffee
+++ b/scripts/deploy.coffee
@@ -24,14 +24,17 @@ module.exports = (robot) ->
       else
         msg.send "--- Deploy finished."
 
-  new cronJob('20 15 * * *', () ->
+  new cronJob('04 04 * * *', () ->
     projects = ["remp", "stbd", "casto"]
 
-    for pj,i in projects
-      exec "cd tmp/#{pj} && bundle exec mina deploy:cleanup", (err, stdout, stderr) ->
+    cleanup = (pjName) ->
+      exec "cd tmp/#{pjName} && bundle exec mina deploy:cleanup", (err, stdout, stderr) ->
         if err
-          robot.send {room:'remp_team'}, "#{pj} container deploy:cleanup failed....."
+          robot.send {room:'remp_team'}, "#{pjName} container deploy:cleanup failed....."
         else
-          robot.send {room:'remp_team'}, "#{pj} container deploy:cleanup success....."
+          robot.send {room:'remp_team'}, "#{pjName} container deploy:cleanup success!!"
+
+    for pj,i in projects
+      cleanup(pj)
 
   ).start()


### PR DESCRIPTION
### 解決したいこと
- プロジェクト毎の `deploy:cleanup` が動いていなかったので修正...
  - 併せて実行時間を4時4分に変更
